### PR TITLE
Switch to new --cask Homebrew CLI option syntax to avoid deprecation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ install: $(TAP_DIR) $(TAP_DIR)/$(REPO_NAME) ## Install Tap via git checkout syml
 	brew tap
 
 test: install ## Run tests
-	brew cask audit $(CASK_NAME)
-	brew cask install --verbose $(CASK_NAME)
+	brew audit --cask $(CASK_NAME)
+	brew install --cask --verbose $(CASK_NAME)
 	pkgutil --pkgs=com.mobileinno.pkg.pCloudDrive
 
 clean:: ## Remove temporary/build files.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Then, run the following in your command-line:
 
 **Note**: For info run:
 
-    brew cask info pcloud-drive
+    brew info --cask pcloud-drive
 
 Once the tap is installed, you can install `truecrypt`!
 
-    brew cask install pcloud-drive
+    brew install --cask pcloud-drive
 
 To uninstall run:
 
-    brew cask uninstall pcloud-drive
+    brew uninstall --cask pcloud-drive
 
 ## Development
 


### PR DESCRIPTION
Fixing future breakages and switch all `brew cask` command verbs to `brew <verb> --cask`