### PR TITLE
Fix #17 - Travis CI builds upgraded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 version: ~> 1.0
 language: objective-c
-osx_image: xcode61
-before_install:
-  - brew update >/dev/null
+osx_image: xcode12.2
+addons:
+  homebrew:
+    brewfile: Brewfile.travis
+    update: true
 install:
   - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ version: ~> 1.0
 language: objective-c
 osx_image: xcode61
 before_install:
-  - brew update
+  - brew update >/dev/null
 install:
   - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 version: ~> 1.0
+os: osx
 language: objective-c
 osx_image: xcode12.2
 addons:
@@ -9,5 +10,5 @@ install:
   - make install
 script:
   - make test
-matrix:
+jobs:
   fast_finish: true

--- a/Brewfile.travis
+++ b/Brewfile.travis
@@ -1,0 +1,5 @@
+# set arguments for all 'brew install --cask' commands
+cask_args appdir: "~/Applications", require_sha: true
+
+# 'brew install --cask'
+cask "macfuse"


### PR DESCRIPTION
- Migrated to newer Travis-CI.com site
- Update to `xcode12.2` / `10.15.7` macOS image
- Add `Brewfile.travis` for dependencies (`macfuse`, was `osxfuse`)