### PR TITLE
Update osx_image to 12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 version: ~> 1.0
 os: osx
 language: objective-c
-osx_image: xcode12.2
+osx_image: xcode12.5
 addons:
   homebrew:
     brewfile: Brewfile.travis


### PR DESCRIPTION
Note: Trying to fix slow `brew update` TravisCI builds...
  - Seems that others are having some success with Xcode 12.5
  - TravisCI `.org` to `.com` migration caused issues with new build credits system 💸🚽

Reference:
  - energymon/energymon#43